### PR TITLE
package.json: add linux-start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "scripts": {
     "start": "./node_modules/electron/dist/Electron.app/Contents/MacOS/Electron main.js",
+    "start-linux": "./node_modules/electron/dist/electron --no-sandbox main.js",
     "package": "./node_modules/electron-packager/bin/electron-packager.js . Cracked --platform=darwin --arch=x64 --icon=./cracked.icns --overwrite --extend-info extend.plist",
     "package-mac": "./node_modules/electron-packager/bin/electron-packager.js . Cracked --platform=darwin --arch=x64 --icon=./cracked.icns --overwrite --extend-info extend.plist",
     "package-linux": "./node_modules/electron-packager/bin/electron-packager.js . Cracked --platform=linux --arch=x64 --icon=./cracked.icns --overwrite",


### PR DESCRIPTION
Note: "--no-sandbox" is needed on some distros to avoid crashing with "GPU process isn't usable", see:
https://github.com/Automattic/simplenote-electron/issues/3044#issuecomment-979289305